### PR TITLE
Fix: Pass missing generate_trace_max_workers parameter

### DIFF
--- a/cent_simulation/simulation.sh
+++ b/cent_simulation/simulation.sh
@@ -12,5 +12,5 @@ python3 run_sim.py --model Llama2-13B --model_parallel --generate_trace --simula
 python3 run_sim.py --model Llama2-70B --model_parallel --generate_trace --simulate_trace --process_results --update_csv --num_devices 32 --run_simulation_max_workers $threads --generate_trace_max_workers $threads --seqlen_gap $seqlen_gap
 
 # Long Context
-python3 run_sim.py --model Llama2-70B --simulation_result_path simulation_results_long_context.csv --generate_trace --simulate_trace --process_results --update_csv --num_devices 32 --run_simulation_max_workers $threads --seqlen 2304 6400 14592 30976
-python3 run_sim.py --model Llama2-70B --model_parallel --inter-device-attention --simulation_result_path simulation_results_long_context.csv --generate_trace --simulate_trace --process_results --update_csv --num_devices 32 --run_simulation_max_workers $threads --seqlen 2304 6400 14592 30976
+python3 run_sim.py --model Llama2-70B --simulation_result_path simulation_results_long_context.csv --generate_trace --simulate_trace --process_results --update_csv --num_devices 32 --run_simulation_max_workers $threads --generate_trace_max_workers $threads --seqlen 2304 6400 14592 30976
+python3 run_sim.py --model Llama2-70B --model_parallel --inter-device-attention --simulation_result_path simulation_results_long_context.csv --generate_trace --simulate_trace --process_results --update_csv --num_devices 32 --run_simulation_max_workers $threads --generate_trace_max_workers $threads --seqlen 2304 6400 14592 30976


### PR DESCRIPTION
Passes the missing `--generate_trace_max_workers $threads` argument in `simulation.sh`. 

Without this argument, the script defaults to 20 threads from `run_sim.py`, which causes crashes during simulation.